### PR TITLE
Add newlines and tab to callback completion

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,12 +94,13 @@ export function activate(context: vscode.ExtensionContext) {
 					}
 
 					const params     = hook.doc.tags.filter( tag => 'param' === tag.name );
-					const argsString = params.map( param => param.variable ).join( ', ' );
+					const argsString = params.map( param => `\\${param.variable}` ).join( ', ' );
 
-					const snippet = 'function (' + ( argsString ? ' ' + argsString + ' ' : '' ) + ') {\n}' + ( params.length ? ', 10, ' + params.length + ' ' : '' );
+					const snippet = 'function (' + ( argsString ? ' ' + argsString + ' ' : '' ) + ') {\n\t${1}\n}' + ( params.length ? ', 10, ' + params.length + ' ' : '' );
 
 					var completion = new vscode.CompletionItem(snippet, vscode.CompletionItemKind.Value);
-
+					completion.insertText = new vscode.SnippetString(snippet);
+					
 					return [
 						completion
 					];


### PR DESCRIPTION
Hi John,

Thanks for the great extension, it's super helpful! I've made a small improvement to the autocompletion of the callback function: VS Code will now automatically insert newlines and a tab to the callback and place the cursor right at the end of the tab (see screenshot). Would love to hear what you think. 

![image](https://user-images.githubusercontent.com/1713699/68505623-fbf13f00-0267-11ea-9515-748cc45a864e.png)
