### PR TITLE
Callback symbol navigation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,8 @@ function isInAction(
 function isInFunctionDeclaration(
 	line: string,
 ): RegExpMatchArray | null {
-	return line.match(/add_(filter|action)\([\s]*['|"]([\S]+?)['|"],[\s]*[\w]*?$/);
+	//                 add_   filter|action  (    '"    {hook}     '" ,
+	return line.match(/add_(?:filter|action)\(\s*['"](?<hook>\S+?)['"],\s*\w*?$/);
 }
 
 function getHook(
@@ -281,7 +282,7 @@ export function activate(
 					return undefined;
 				}
 
-				const hook = getHook(declaration[2]);
+				const hook = getHook(declaration.groups?.hook || '');
 
 				if (!hook) {
 					return undefined;


### PR DESCRIPTION
This implements #22.

"Go to Definition" is complete for:

* [ ] Namespaced functions (`__NAMESPACE__ . '\\foo'`)
* [x] Global functions (`'foo'`)
* [ ] Class instance methods (`[ $this, 'foo' ]` and `array( $this, 'foo' )`)
* [ ] Static class methods (`'className::foo'`, `[ 'className', 'foo' ]`, and `array( 'className', 'foo' )`)